### PR TITLE
fix(ImageService, ThumbnailService): change delete method

### DIFF
--- a/hotel-booking-app/Services/ImageService.cs
+++ b/hotel-booking-app/Services/ImageService.cs
@@ -138,7 +138,7 @@ namespace HotelBookingApp.Services
         {
             var pathInBlob = path.Split(blobContainerName + "/")[1];
             var blob = blobContainer.GetBlockBlobReference(pathInBlob);
-            await blob.DeleteAsync();
+            await blob.DeleteIfExistsAsync();
         }
 
         public async Task DeleteAllFileAsync(int hotelId)

--- a/hotel-booking-app/Services/ThumbnailService.cs
+++ b/hotel-booking-app/Services/ThumbnailService.cs
@@ -69,7 +69,7 @@ namespace HotelBookingApp.Services
         {
             var fileName = hotelId.ToString() + ".jpg";
             var blob = blobContainer.GetBlockBlobReference(fileName);
-            await blob.DeleteAsync();
+            await blob.DeleteIfExistsAsync();
         }
 
         public async Task UpdateThumbnail(int hotelId, IFormFile file)


### PR DESCRIPTION
DeleteAsync methods have been changed to DeleteIfExistsAsync methods.

This way it does not throw exception if the blob which has to be deleted does not exists.