### PR TITLE
Fix/caching thumbnail

### DIFF
--- a/hotel-booking-app/Views/Hotels/Hotel.cshtml
+++ b/hotel-booking-app/Views/Hotels/Hotel.cshtml
@@ -10,7 +10,8 @@
         <div>
             @if (Model.Hotel.ThumbnailUrl != null && Model.Hotel.Thumbnail)
             {
-                <img class="img-fluid" src="@Model.Hotel.ThumbnailUrl?" + DateTime.Now.ToString("ddyyhhmmss") alt="thumbnail" />
+                var timestamp = DateTime.Now.ToString("ddyyhhmmss");
+                <img class="img-fluid" src="@Model.Hotel.ThumbnailUrl?@timestamp"  alt="thumbnail" />
             }
             else
             {

--- a/hotel-booking-app/Views/Hotels/Index.cshtml
+++ b/hotel-booking-app/Views/Hotels/Index.cshtml
@@ -68,7 +68,8 @@
                     <td>
                         @if (hotel != null && hotel.Thumbnail)
                         {
-                            <img src="@hotel.ThumbnailUrl?" + DateTime.Now.ToString("ddyyhhmmss") />
+                            var timestamp = DateTime.Now.ToString("ddyyhhmmss");
+                            <img src="@hotel.ThumbnailUrl?@timestamp" />
                         }
                         else
                         {


### PR DESCRIPTION
Loading thumbnails if they were changed on page load.

Timestamp added as query param to image url, which force browser to reload image if it (url) is changed.